### PR TITLE
chore(html-report): disabled lcov and enable html for merge reports

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,9 +76,10 @@ jobs:
       - merge-coverage-reports
       - run:
           name: generate coverage report
+          # it appears that lcov report can flake ttps://github.com/istanbuljs/istanbuljs/issues/572, therefore using html report
           command: |
             npx nyc report \
-              --reporter lcov --reporter text-summary \
+              --reporter html --reporter text-summary \
               --report-dir combined-coverage
       - store_artifacts:
           path: combined-coverage

--- a/cypress/.gitlab-ci-tests.yml
+++ b/cypress/.gitlab-ci-tests.yml
@@ -5,7 +5,7 @@ variables:
 # these are properties that are common in every Cypress job
 .branch_template: &common
   image:
-    name: cypress/included:7.2.0
+    name: cypress/included:7.3.0
     entrypoint: [""]
   artifacts:
     expire_in: 1 week


### PR DESCRIPTION
 it appears that lcov report can flake when merging reports https://github.com/istanbuljs/istanbuljs/issues/572, therefore using html report